### PR TITLE
[add] add filter for register book

### DIFF
--- a/rent-book-api/app/controllers/api/v1/admin/register_books_controller.rb
+++ b/rent-book-api/app/controllers/api/v1/admin/register_books_controller.rb
@@ -3,6 +3,14 @@ class Api::V1::Admin::RegisterBooksController < ApplicationController
   authorize_resource
   before_action :load_register_book, :load_books, only: :update
 
+  def index
+    search = RegisterBook.ransack(params[:search])
+    page = params[:page] || Settings.register_book.page
+    per_page = params[:per_page] || Settings.register_book.per_page
+    register_books = search.result.page(page).per(per_page)
+    json_response register_books, meta_pagination(page, per_page, register_books)
+  end
+
   def update
     if params[:status] == Settings.register_book.status.rejected
       ActiveRecord::Base.transaction do

--- a/rent-book-api/app/models/ability.rb
+++ b/rent-book-api/app/models/ability.rb
@@ -7,7 +7,7 @@ class Ability
 
   def admin_abilities _user
     can :manage, Book
-    can :update, RegisterBook
+    can [:read, :update], RegisterBook
   end
 
   def user_abilities user

--- a/rent-book-api/config/routes.rb
+++ b/rent-book-api/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
         post "sign_up", to: "registrations#create"
         namespace :admin do
           resources :books
-          resources :register_books, only: :update
+          resources :register_books, only: %i(index update)
         end
         resources :books, only: %i(index show) do
           resources :comments, except: %i(new edit show)

--- a/rent-book-api/config/settings.yml
+++ b/rent-book-api/config/settings.yml
@@ -26,6 +26,8 @@ comment:
 register_book:
   status:
     rejected: "rejected"
+  page: 1
+  per_page: 10
 register_book_detail:
   quantity:
     gteq: 0

--- a/rent-book-api/spec/controllers/api/v1/admin/register_books_controller_spec.rb
+++ b/rent-book-api/spec/controllers/api/v1/admin/register_books_controller_spec.rb
@@ -5,8 +5,37 @@ RSpec.describe Api::V1::Admin::RegisterBooksController, type: :controller do
   let!(:book){FactoryBot.create(:book)}
   let!(:register_book){FactoryBot.create(:register_book, user: user)}
   let!(:register_book_details){FactoryBot.create(:register_book_detail, register_book: register_book, book: book)}
-
+  let(:filter_expected_repsonse){{register_books:
+                                  [RegisterBookSerializer.new(register_book).attributes],
+                                  meta: {page: 1, per_page: 10, total_page: 1}}.to_json}
   include_examples "login", :admin
+
+  describe "GET #index" do
+
+    context "filter by start date" do
+      subject{get :index, params: {search: {start_date_cont: register_book.start_date}}}
+
+      it "search register book successfully" do
+        subject
+        expect(response.body).to eq(filter_expected_repsonse)
+      end
+
+      include_examples "response http status", :ok
+      include_examples "index valid json", "register_books", 1
+    end
+
+    context "filter between start date" do
+      subject{get :index, params: {search: {start_date_gteq: register_book.start_date, start_date_lteq: register_book.start_date}}}
+
+      it "search register book successfully" do
+        subject
+        expect(response.body).to eq(filter_expected_repsonse)
+      end
+
+      include_examples "response http status", :ok
+      include_examples "index valid json", "register_books", 1
+    end
+  end
 
   describe "PUT #update" do
     context "approve register book" do


### PR DESCRIPTION
## Related Tickets
- None

## WHY
- Admin can filter register book.

## HOW
- Create api for filter 
```
/api/v1/admin/register_book
{
   search : {
      "start_date_cont": "18-09-2020",
      "end_date_cont": "20-09-2020"
   }
}
```
or
Filter between
```
/api/v1/admin/register_book
{
   search : {
      "start_date_gteq": "18-09-2020",
      "start_date_lteq": "20-09-2020"
   }
}
```
## Evidence (Screenshot or Video)
- Rspec
![image](https://user-images.githubusercontent.com/64879855/93576979-b348fd00-f9c5-11ea-8342-9a3fb48d1eb2.png)
-Rubocop
![image](https://user-images.githubusercontent.com/64879855/93577906-d58f4a80-f9c6-11ea-8caa-aacf38fb2377.png)

## Impacted Areas in Application (Optional)


## Checklist
- [ ] Unit test run successfully?
- [ ] Updated library at [here](https://???)
- [ ] Fill link PR into ticket and the opposite
- [ ] Note reason, scope of influence, solution into ticket
- [ ] Validate UI/Model/API
- [ ] Checked on iPhone 5, 7, X
- [ ] Followed latest specs at [#Link specs](https://???)

## Library (Optional)
*(Liệt kê danh sách thư viện, các ứng của bên thứ 3 sử dụng trong PR bao gồm cả phiên bản sử dụng)*

- Library: GoogleAnalysis v1.2.0

## Performance (Optional)
- [ ] Resolved n + 1 query
- [ ] Time run rake task : 1000 ms
- Generated SQL query

## Notes (Optional)
- None
